### PR TITLE
OTAP exporter stream concurrency

### DIFF
--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/config.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/config.rs
@@ -36,6 +36,13 @@ pub struct Config {
     )]
     pub stream_queue_capacity: usize,
 
+    /// Number of independent gRPC streams to run for each signal type.
+    #[serde(
+        default = "default_streams_per_signal",
+        deserialize_with = "deserialize_positive_streams_per_signal"
+    )]
+    pub streams_per_signal: usize,
+
     /// Timeout for RPC requests. If not specified, no timeout is applied.
     /// Format: humantime format (e.g., "30s", "5m", "1h", "500ms")
     #[serde(default, with = "humantime_serde")]
@@ -91,6 +98,10 @@ const fn default_stream_queue_capacity() -> usize {
     64
 }
 
+const fn default_streams_per_signal() -> usize {
+    1
+}
+
 fn deserialize_positive_usize<'de, D>(deserializer: D, field_name: &str) -> Result<usize, D::Error>
 where
     D: Deserializer<'de>,
@@ -109,6 +120,13 @@ where
     D: Deserializer<'de>,
 {
     deserialize_positive_usize(deserializer, "stream_queue_capacity")
+}
+
+fn deserialize_positive_streams_per_signal<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_positive_usize(deserializer, "streams_per_signal")
 }
 
 /// helper method to deserialize the text "none" as the None option. This is needed to override

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -371,9 +371,14 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                 .accept_compressed(encoding);
         }
 
-        // TODO comment on the purpose of these
-        // TODO import so can use as just "channel" here
-        // TODO check if we can use our local channel since we are already using `tokio::task::spawn_local`.
+        // Each signal type is exported through one or more long-lived stream
+        // workers. The exporter task only converts incoming pdata and enqueues
+        // it into a bounded per-stream queue; the worker owns the gRPC request
+        // stream and response correlation for that queue.
+        //
+        // Keeping these queues bounded preserves backpressure. Increasing
+        // `streams_per_signal` adds independently progressing gRPC streams
+        // instead of hiding pressure behind a deeper single queue.
         let stream_queue_capacity = self.config.stream_queue_capacity;
         let streams_per_signal = self.config.streams_per_signal;
         let (pdata_metrics_tx, mut pdata_metrics_rx) = tokio::sync::mpsc::channel(64);
@@ -384,7 +389,9 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         )
         .then(|| arrow_ipc::CompressionType::ZSTD);
 
-        // TODO check if we can expose/use spawn_local method in the effect handler
+        // Tonic clients are cheap to clone because they share the underlying
+        // Channel. Each clone below is used by exactly one worker, which lets
+        // the workers drive separate streaming RPCs concurrently.
         let (logs_senders, logs_handles) = spawn_stream_workers(
             arrow_logs_client,
             SignalType::Logs,
@@ -468,6 +475,10 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                             }
                         };
 
+                        // Route each batch to the stream with the smallest
+                        // local backlog. This is intentionally based on queue
+                        // occupancy, not response latency: queue depth is the
+                        // backpressure signal available before enqueueing.
                         let sender = match signal_type {
                             SignalType::Logs => least_loaded_stream_sender(&logs_senders),
                             SignalType::Metrics => least_loaded_stream_sender(&metrics_senders),
@@ -501,6 +512,12 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
     }
 }
 
+/// Starts the per-signal stream worker pool.
+///
+/// Each worker receives batches through its own bounded queue and turns those
+/// batches into one streaming RPC. Multiple workers therefore mean multiple
+/// independent HTTP/2 request/response streams for the same signal type. That
+/// is the behavior controlled by `streams_per_signal`.
 fn spawn_stream_workers<T>(
     client: T,
     signal_type: SignalType,
@@ -517,6 +534,9 @@ where
     let mut handles = Vec::with_capacity(streams_per_signal);
 
     for _ in 0..streams_per_signal {
+        // The queue is per stream, not shared across the pool. This keeps
+        // backpressure local to the stream that is lagging and gives the
+        // exporter a useful depth signal for least-loaded routing.
         let (sender, receiver) = tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
         senders.push(sender);
         handles.push(tokio::task::spawn_local(stream_arrow_batches(
@@ -532,6 +552,11 @@ where
     (senders, handles)
 }
 
+/// Selects the stream queue with the smallest current backlog.
+///
+/// `tokio::sync::mpsc::Sender` exposes remaining capacity rather than length,
+/// so occupancy is computed as `max_capacity - capacity`. The config rejects
+/// `streams_per_signal = 0`, which makes the final `expect` an invariant check.
 fn least_loaded_stream_sender(senders: &[Sender<StreamBatch>]) -> &Sender<StreamBatch> {
     senders
         .iter()
@@ -539,6 +564,11 @@ fn least_loaded_stream_sender(senders: &[Sender<StreamBatch>]) -> &Sender<Stream
         .expect("streams_per_signal validation must create at least one stream")
 }
 
+/// Waits for all stream workers belonging to one signal type.
+///
+/// Worker errors are already represented through pdata ACK/NACK updates where
+/// possible; a join failure during shutdown should not prevent the exporter
+/// from completing its terminal-state path.
 async fn await_stream_handles(handles: Vec<JoinHandle<()>>) {
     for handle in handles {
         _ = handle.await;

--- a/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
+++ b/rust/otap-dataflow/crates/core-nodes/src/exporters/otap_exporter/mod.rs
@@ -42,6 +42,7 @@ use serde_json::Value;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::task::JoinHandle;
 use tonic::transport::Channel;
 use tonic::{IntoStreamingRequest, Response, Status, Streaming};
 
@@ -374,12 +375,7 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         // TODO import so can use as just "channel" here
         // TODO check if we can use our local channel since we are already using `tokio::task::spawn_local`.
         let stream_queue_capacity = self.config.stream_queue_capacity;
-        let (logs_sender, logs_receiver) =
-            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
-        let (metrics_sender, metrics_receiver) =
-            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
-        let (traces_sender, traces_receiver) =
-            tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
+        let streams_per_signal = self.config.streams_per_signal;
         let (pdata_metrics_tx, mut pdata_metrics_rx) = tokio::sync::mpsc::channel(64);
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let ipc_compression = matches!(
@@ -389,30 +385,33 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
         .then(|| arrow_ipc::CompressionType::ZSTD);
 
         // TODO check if we can expose/use spawn_local method in the effect handler
-        let logs_handle = tokio::task::spawn_local(stream_arrow_batches(
+        let (logs_senders, logs_handles) = spawn_stream_workers(
             arrow_logs_client,
             SignalType::Logs,
             ipc_compression,
-            logs_receiver,
+            stream_queue_capacity,
+            streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
-        ));
-        let metrics_handle = tokio::task::spawn_local(stream_arrow_batches(
+        );
+        let (metrics_senders, metrics_handles) = spawn_stream_workers(
             arrow_metrics_client,
             SignalType::Metrics,
             ipc_compression,
-            metrics_receiver,
+            stream_queue_capacity,
+            streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
-        ));
-        let traces_handle = tokio::task::spawn_local(stream_arrow_batches(
+        );
+        let (traces_senders, traces_handles) = spawn_stream_workers(
             arrow_traces_client,
             SignalType::Traces,
             ipc_compression,
-            traces_receiver,
+            stream_queue_capacity,
+            streams_per_signal,
             pdata_metrics_tx.clone(),
             shutdown_rx.clone(),
-        ));
+        );
 
         // Loop until a Shutdown event is received.
         loop {
@@ -442,9 +441,9 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                             message = "OTAP Exporter shutting down"
                         );
                         _ = shutdown_tx.send_replace(true);
-                        _ = logs_handle.await;
-                        _ = metrics_handle.await;
-                        _ = traces_handle.await;
+                        await_stream_handles(logs_handles).await;
+                        await_stream_handles(metrics_handles).await;
+                        await_stream_handles(traces_handles).await;
                         _ = timer_cancel_handle.cancel().await;
                         self.export_latency_window
                             .report_into(&mut self.async_metrics);
@@ -470,9 +469,9 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                         };
 
                         let sender = match signal_type {
-                            SignalType::Logs => &logs_sender,
-                            SignalType::Metrics => &metrics_sender,
-                            SignalType::Traces => &traces_sender,
+                            SignalType::Logs => least_loaded_stream_sender(&logs_senders),
+                            SignalType::Metrics => least_loaded_stream_sender(&metrics_senders),
+                            SignalType::Traces => least_loaded_stream_sender(&traces_senders),
                         };
                         self.enqueue_stream_batch(
                             sender,
@@ -499,6 +498,50 @@ impl local::Exporter<OtapPdata> for OTAPExporter {
                 }
             }
         }
+    }
+}
+
+fn spawn_stream_workers<T>(
+    client: T,
+    signal_type: SignalType,
+    ipc_compression: Option<arrow_ipc::CompressionType>,
+    stream_queue_capacity: usize,
+    streams_per_signal: usize,
+    pdata_metrics_tx: Sender<PDataMetricsUpdate>,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> (Vec<Sender<StreamBatch>>, Vec<JoinHandle<()>>)
+where
+    T: StreamingArrowService + Clone + 'static,
+{
+    let mut senders = Vec::with_capacity(streams_per_signal);
+    let mut handles = Vec::with_capacity(streams_per_signal);
+
+    for _ in 0..streams_per_signal {
+        let (sender, receiver) = tokio::sync::mpsc::channel::<StreamBatch>(stream_queue_capacity);
+        senders.push(sender);
+        handles.push(tokio::task::spawn_local(stream_arrow_batches(
+            client.clone(),
+            signal_type,
+            ipc_compression,
+            receiver,
+            pdata_metrics_tx.clone(),
+            shutdown_rx.clone(),
+        )));
+    }
+
+    (senders, handles)
+}
+
+fn least_loaded_stream_sender(senders: &[Sender<StreamBatch>]) -> &Sender<StreamBatch> {
+    senders
+        .iter()
+        .min_by_key(|sender| sender.max_capacity() - sender.capacity())
+        .expect("streams_per_signal validation must create at least one stream")
+}
+
+async fn await_stream_handles(handles: Vec<JoinHandle<()>>) {
+    for handle in handles {
+        _ = handle.await;
     }
 }
 
@@ -1072,6 +1115,7 @@ mod tests {
 
         assert_eq!(exporter.config.grpc.grpc_endpoint, "http://localhost:4317");
         assert_eq!(exporter.config.stream_queue_capacity, 64);
+        assert_eq!(exporter.config.streams_per_signal, 1);
         match exporter.config.compression_method {
             Some(ref method) => match method {
                 CompressionMethod::Gzip => {} // success
@@ -1122,6 +1166,22 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_with_streams_per_signal() {
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "streams_per_signal": 4
+        });
+        let exporter =
+            OTAPExporter::from_config(pipeline_ctx, &json_config).expect("Config should be valid");
+        assert_eq!(exporter.config.streams_per_signal, 4);
+    }
+
+    #[test]
     fn test_from_config_rejects_zero_stream_queue_capacity() {
         let telemetry_registry_handle = TelemetryRegistryHandle::new();
         let controller_ctx = ControllerContext::new(telemetry_registry_handle);
@@ -1137,6 +1197,24 @@ mod tests {
             Err(err) => err,
         };
         assert!(format!("{err}").contains("stream_queue_capacity must be greater than 0"));
+    }
+
+    #[test]
+    fn test_from_config_rejects_zero_streams_per_signal() {
+        let telemetry_registry_handle = TelemetryRegistryHandle::new();
+        let controller_ctx = ControllerContext::new(telemetry_registry_handle);
+        let pipeline_ctx =
+            controller_ctx.pipeline_context_with("grp".into(), "pipeline".into(), 0, 1, 0);
+
+        let json_config = json!({
+            "grpc_endpoint": "http://localhost:4317",
+            "streams_per_signal": 0
+        });
+        let err = match OTAPExporter::from_config(pipeline_ctx, &json_config) {
+            Ok(_) => panic!("zero streams per signal should fail"),
+            Err(err) => err,
+        };
+        assert!(format!("{err}").contains("streams_per_signal must be greater than 0"));
     }
 
     #[test]


### PR DESCRIPTION
# Change Summary

Add configurable `streams_per_signal` support to the OTAP exporter so each signal type can use multiple independent gRPC streaming RPCs.

Before this change, each signal type had a single bounded queue feeding a single stream worker. Large OTAP payloads could saturate that one stream path even when backend CPU was not saturated. Increasing the queue capacity only moved the pressure into deeper buffering; it did not increase the service rate of the stream path.

This PR changes the exporter shape to:

```text
signal pdata
  -> select signal-specific worker pool
  -> pick least-loaded per-stream queue
  -> stream worker owns one gRPC request/response stream
  -> response reader correlates BatchStatus responses back to pdata ACK/NACK
```

Key implementation details:

- `streams_per_signal` defaults to `1`, preserving current behavior unless configured.
- The value is validated as strictly greater than zero.
- Each signal type gets its own worker pool: logs, metrics, and traces are still separated.
- Each worker has its own bounded `tokio::sync::mpsc` queue with the existing `stream_queue_capacity`.
- Each worker drives one long-lived OTAP Arrow streaming RPC.
- Batches are routed to the stream queue with the smallest current backlog.
- Routing uses queue occupancy (`max_capacity - capacity`) because that is the local backpressure signal available before enqueueing.
- Tonic clients are cloned per worker; clones share the underlying channel but let workers drive independent streams.
- Shutdown now waits for all workers belonging to each signal type.

The intent is to increase concurrency at the stream-service point without hiding backpressure behind a larger queue.

## Performance Evaluation

E160-E162 identified single-stream OTAP export as the active large-payload limiter. For `10000@600k`, moving from one stream to two streams changed the run from `0/6` accepted windows at `326k logs/s` to `3/4` accepted windows at `600k logs/s`.

Measured improvements from `1` to `2` streams:

- CPU/log: `754ns` -> `393ns`
- clean context switches: `151/s` -> `103/s`
- loadgen p99 average: `328ms` -> `40.5ms`
- SUT stream queue depth: `63.9` -> `1.0`
- delivered throughput: `326k logs/s` -> `600k logs/s`

Four streams further reduced CPU/log to `346ns`, clean context switches to `75/s`, and `epoll_wait/s` to `88/s`, but p99 max was worse than the two-stream run. Based on the current evidence, `2` streams is the conservative large-payload candidate and `4` streams needs more p99 validation.

E163-E165 isolated the effect: SUT-side stream concurrency was necessary. Increasing only loadgen streams left the SUT stream queue pinned at capacity and kept throughput around the low `300k logs/s` range. Increasing SUT streams collapsed the SUT stream queue and made the workload rankable.

E166-E168 checked for regressions on the clean `5000@1.20M` reference. SUT `2` streams was CPU-neutral, lowered clean context switches and `epoll_wait/s`, and kept zero warnings. p99 max was noisier, so this should still be treated as a strong large-payload candidate rather than a universal default without more repeat validation.

## What issue does this PR close?

No GitHub issue is currently linked. Follow-up from the SUT performance investigation around OTAP exporter stream saturation.

## Validation

- `cargo fmt --all`
- `cargo test -p otap-df-core-nodes test_from_config_with_streams_per_signal`
- `cargo test -p otap-df-core-nodes test_from_config_rejects_zero_streams_per_signal`

Note: `cargo check -p otap-df-core-nodes` currently fails while compiling `otap-df-otap` without `rustls/ring`; the focused tests above compile and run through the same exporter test target used for this PR.

This PR is stacked on `otap-exporter-progress-metrics`.
